### PR TITLE
Add LCWrapperKernelSpecManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Append the below line to `jupyter_notebook_config.py`.
 c.MultiKernelManager.kernel_manager_class = 'lc_wrapper.LCWrapperKernelManager'
 ```
 
+#### Replace KernelSpecManager (optional)
+
+If you want to completely replace the Python or Bash kernel in the kernel selection list with the wrapper kernel,
+you can use the custom kernel spec manager (`lc_wrapper.LCWrapperKernelSpecManager`).
+This custom kernel spec manager provides another kernel spec list that is separated from the default kernel spec list.
+
+Append the following line to `jupyter_notebook_config.py`
+
+```
+c.NotebookApp.kernel_spec_manager_class = 'lc_wrapper.LCWrapperKernelSpecManager'
+```
+
+If you want to install additional kernels to this kernel spec list,
+you can use `jupyter wrapper-kernelspec` command like `jupyter kernelspec` command.
+For details, please execute `jupyter wrapper-kernelspec --help`.
 
 ## How to Use
 

--- a/lc_wrapper/__init__.py
+++ b/lc_wrapper/__init__.py
@@ -1,6 +1,7 @@
 """Wrapper Kernel for Literate Computing"""
 
 from .kernel import LCWrapperKernelManager
+from .kernelspec import LCWrapperKernelSpecManager
 
 # nbextension
 def _jupyter_nbextension_paths():

--- a/lc_wrapper/bash/install.py
+++ b/lc_wrapper/bash/install.py
@@ -6,24 +6,33 @@ import sys
 from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
-kernel_json = {
+from ..kernelspec import LCWrapperKernelSpecManager
+
+wrapper_kernel_json = {
     "argv": [sys.executable, "-m", "lc_wrapper.bash", "-f", "{connection_file}"],
     "display_name": "LC_wrapper_bash",
     "language": "bash"
 }
 
-def install_my_kernel_spec(user=True, prefix=None):
+kernel_json = {
+    "argv": [sys.executable, "-m", "lc_wrapper.bash", "-f", "{connection_file}"],
+    "display_name": "Bash",
+    "language": "bash"
+}
+
+def install_my_kernel_spec(name, kernel_json, user=True, prefix=None,
+                           kernelspec_manager_class=KernelSpecManager):
     with TemporaryDirectory() as td:
         os.chmod(td, 0o755) # Starts off as 700, not user readable
         with open(os.path.join(td, 'kernel.json'), 'w') as f:
             json.dump(kernel_json, f, sort_keys=True)
 
-        print('Installing Jupyter kernel spec')
-        KernelSpecManager().install_kernel_spec(td,
-                                                'lc_wrapper_bash',
-                                                user=user,
-                                                replace=True,
-                                                prefix=prefix)
+        kernelspec_manager = kernelspec_manager_class()
+        kernelspec_manager.install_kernel_spec(td,
+                                               name,
+                                               user=user,
+                                               replace=True,
+                                               prefix=prefix)
 
 def _is_root():
     try:
@@ -47,7 +56,13 @@ def main(argv=None):
     if not args.prefix and not _is_root():
         args.user = True
 
-    install_my_kernel_spec(user=args.user, prefix=args.prefix)
+    print('Installing Jupyter kernel spec')
+    install_my_kernel_spec('lc_wrapper_bash', wrapper_kernel_json,
+                           user=args.user, prefix=args.prefix,
+                           kernelspec_manager_class=KernelSpecManager)
+    install_my_kernel_spec('bash', kernel_json,
+                           user=args.user, prefix=args.prefix,
+                           kernelspec_manager_class=LCWrapperKernelSpecManager)
 
 if __name__ == '__main__':
     main()

--- a/lc_wrapper/ipython/install.py
+++ b/lc_wrapper/ipython/install.py
@@ -3,27 +3,38 @@ import json
 import os
 import sys
 
+from ipython_genutils.py3compat import PY3
 from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
-kernel_json = {
+from ..kernelspec import LCWrapperKernelSpecManager
+
+wrapper_kernel_json = {
     "argv": [sys.executable, "-m", "lc_wrapper.ipython", "-f", "{connection_file}"],
     "display_name": "LC_wrapper",
     "language": "python"
 }
 
-def install_my_kernel_spec(user=True, prefix=None):
+kernel_json = {
+    "argv": [sys.executable, "-m", "lc_wrapper.ipython", "-f", "{connection_file}"],
+    "display_name": 'Python %i' % sys.version_info[0],
+    "language": "python"
+}
+
+
+def install_my_kernel_spec(name, kernel_json, user=True, prefix=None,
+                           kernelspec_manager_class=KernelSpecManager):
     with TemporaryDirectory() as td:
         os.chmod(td, 0o755) # Starts off as 700, not user readable
         with open(os.path.join(td, 'kernel.json'), 'w') as f:
             json.dump(kernel_json, f, sort_keys=True)
 
-        print('Installing Jupyter kernel spec')
-        KernelSpecManager().install_kernel_spec(td,
-                                                'lc_wrapper',
-                                                user=user,
-                                                replace=True,
-                                                prefix=prefix)
+        kernelspec_manager = kernelspec_manager_class()
+        kernelspec_manager.install_kernel_spec(td,
+                                               name,
+                                               user=user,
+                                               replace=True,
+                                               prefix=prefix)
 
 def _is_root():
     try:
@@ -47,7 +58,13 @@ def main(argv=None):
     if not args.prefix and not _is_root():
         args.user = True
 
-    install_my_kernel_spec(user=args.user, prefix=args.prefix)
+    print('Installing Jupyter kernel spec')
+    install_my_kernel_spec('lc_wrapper', wrapper_kernel_json,
+                           user=args.user, prefix=args.prefix,
+                           kernelspec_manager_class=KernelSpecManager)
+    install_my_kernel_spec('python3' if PY3 else 'python2', kernel_json,
+                           user=args.user, prefix=args.prefix,
+                           kernelspec_manager_class=LCWrapperKernelSpecManager)
 
 if __name__ == '__main__':
     main()

--- a/lc_wrapper/kernelspec.py
+++ b/lc_wrapper/kernelspec.py
@@ -1,0 +1,28 @@
+import os.path
+
+from jupyter_core.paths import jupyter_path, SYSTEM_JUPYTER_PATH
+from jupyter_client.kernelspec import KernelSpecManager
+
+
+class LCWrapperKernelSpecManager(KernelSpecManager):
+
+    def _user_kernel_dir_default(self):
+        return os.path.join(self.data_dir, 'lc_wrapper_kernels')
+
+    def _kernel_dirs_default(self):
+        return jupyter_path('lc_wrapper_kernels')
+
+    def _ensure_native_kernel_default(self):
+        return False
+
+    def _get_destination_dir(self, kernel_name, user=False, prefix=None):
+        if user:
+            return os.path.join(self.user_kernel_dir, kernel_name)
+        elif prefix:
+            return os.path.join(os.path.abspath(prefix),
+                                'share', 'jupyter', 'lc_wrapper_kernels',
+                                kernel_name)
+        else:
+            return os.path.join(SYSTEM_JUPYTER_PATH[0],
+                                'lc_wrapper_kernels',
+                                kernel_name)

--- a/lc_wrapper/kernelspecapp.py
+++ b/lc_wrapper/kernelspecapp.py
@@ -1,0 +1,44 @@
+from traitlets import Instance, Dict
+from jupyter_client.kernelspecapp import (ListKernelSpecs,
+                                          InstallKernelSpec,
+                                          RemoveKernelSpec,
+                                          KernelSpecApp)
+from .kernelspec import LCWrapperKernelSpecManager
+
+
+class LCWrapperListKernelSpecs(ListKernelSpecs):
+    kernel_spec_manager = Instance(LCWrapperKernelSpecManager)
+
+    def _kernel_spec_manager_default(self):
+        return LCWrapperKernelSpecManager(parent=self, data_dir=self.data_dir)
+
+
+class LCWrapperInstallKernelSpec(InstallKernelSpec):
+    kernel_spec_manager = Instance(LCWrapperKernelSpecManager)
+
+    def _kernel_spec_manager_default(self):
+        return LCWrapperKernelSpecManager(parent=self, data_dir=self.data_dir)
+
+
+class LCWrapperRemoveKernelSpec(RemoveKernelSpec):
+    kernel_spec_manager = Instance(LCWrapperKernelSpecManager)
+
+    def _kernel_spec_manager_default(self):
+        return LCWrapperKernelSpecManager(parent=self, data_dir=self.data_dir)
+
+
+class LCWrapperKernelSpecApp(KernelSpecApp):
+    subcommands = Dict({
+        'list':      (LCWrapperListKernelSpecs,
+                      ListKernelSpecs.description.splitlines()[0]),
+        'install':   (LCWrapperInstallKernelSpec,
+                      InstallKernelSpec.description.splitlines()[0]),
+        'uninstall': (LCWrapperRemoveKernelSpec,
+                      "Alias for remove"),
+        'remove':    (LCWrapperRemoveKernelSpec,
+                      RemoveKernelSpec.description.splitlines()[0]),
+    })
+
+
+if __name__ == '__main__':
+    LCWrapperKernelSpecApp.launch_instance()

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,10 @@ setup(
     author='NII Cloud Operation Team',
     url='https://github.com/NII-cloud-operation/',
     include_package_data=True,
-    zip_safe=False
+    zip_safe=False,
+    entry_points = {
+        'console_scripts': [
+            'jupyter-wrapper-kernelspec = lc_wrapper.kernelspecapp:LCWrapperKernelSpecApp.launch_instance'
+        ]
+    }
 )


### PR DESCRIPTION
This custom kernel spec manager provides another kernel spec list that is separated from the default kernel spec list.
You can use it in order to completely replace the Python or Bash kernel in the kernel selection list with the wrapper kernel.