### PR TITLE
Implement functionality for masking credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This is an example of `.lc_wrapper` file.
 lc_wrapper_force=on
 lc_wrapper=2:2:2:2
 lc_wrapper_regex=3|5|7
+lc_wrapper_masking_pattern=(?:[0-9]{11}@[a-z]*.proxy.example.com:8080)|AKIAJTQHFTLP426OCK3Q|2468
 ```
 
 #### `lc_wrapper_force`
@@ -241,6 +242,55 @@ Output Size(byte): 189, Lines: 16, Path: /notebooks/.log/20170426/20170426-14391
 9
 ```
 
+#### `lc_wrapper_masking_pattern`
+
+Mask the keywords of the output and log file with variable 'lc_wrapper_masking_pattern'.
+
+The meaning of value is as follows.
+
+```
+lc_wrapper_masking_pattern=z
+z = keywords : If mask two words word1 and word2, write with a separator '|' such as z = word1|word2.
+z = regex : If use regular expression, write with a regular expression such as z = [0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com.
+z = keywords | regex : If use words and regular expression, write with a separator '|' such as z = word1|word2|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com
+```
+
+Example1: `lc_wrapper_masking_pattern=home|123`
+
+```
+[In]
+---
+!!print("home is 123")
+
+[Out]
+---
+path: /notebooks/.log/20181127/20181127-032445-0875.log (2 logs recorded)
+start time: 2018-11-27 03:24:45(UTC)
+end time: 2018-11-27 03:24:45(UTC)
+output size: 474 bytes
+0 chunks with matched keywords or errors
+----
+**** is ***
+```
+
+Example2: `lc_wrapper_masking_pattern=home|abc|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com`
+
+```
+[In]
+---
+!!print("home,123,jamine_wewe@163.com")
+
+[Out]
+---
+path: /notebooks/.log/20181127/20181127-054528-0906.log (9 logs recorded)
+start time: 2018-11-27 05:45:28(UTC)
+end time: 2018-11-27 05:45:28(UTC)
+output size: 494 bytes
+0 chunks with matched keywords or errors
+----
+****,123,*******************
+```
+
 ### Settings by environment variables
 
 Instead of the configuration file, you can set with the environment variables.
@@ -251,6 +301,7 @@ For example, set the environment variables as follows.
 $ export lc_wrapper_force='on'
 $ export lc_wrapper='2:2:2:2'
 $ export lc_wrapper_regex='3|5|7'
+$ export lc_wrapper_masking_pattern='[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com'
 ```
 
 The name of environemnt variable is same to the key name of the configuration file.

--- a/lc_wrapper/kernel.py
+++ b/lc_wrapper/kernel.py
@@ -38,6 +38,7 @@ from fluent import sender
 SUMMARIZE_KEY = 'lc_wrapper'
 IGNORE_SUMMARIZE_KEY = 'lc_wrapper_regex'
 FORCE_SUMMARIZE_KEY = 'lc_wrapper_force'
+MASKING_KEY = 'lc_wrapper_masking_pattern'
 
 IPYTHON_DEFAULT_PATTERN_FILE = '.lc_wrapper_regex.txt'
 IPYTHON_DEFAULT_PATTERN = '''ERROR|error|Error|Panic|panic|Invalid|invalid|Warning|warning|Bad|bad
@@ -589,6 +590,11 @@ class BufferedKernelBase(Kernel):
 
         self.log_history_data = self._read_log_history_file()
 
+        if MASKING_KEY in env:
+            self.masking_pattern = re.compile(env.get(MASKING_KEY))
+        else:
+            self.masking_pattern = None
+
         self.repatter = []
         text = env.get(IGNORE_SUMMARIZE_KEY, 'file:default')
         if text is None or len(text) == 0:
@@ -787,6 +793,7 @@ class BufferedKernelBase(Kernel):
             if 'ExecutionResult' in content['text']:
                 return content
             else:
+                content['text'] = self._mask_lines(content['text'])  # Replace secret patterns with asterisks
                 self.log_buff_append(content['text'])
                 self._log_buff_flush()
 
@@ -882,6 +889,19 @@ class BufferedKernelBase(Kernel):
                                   track=False,
                                   header=None,
                                   metadata=None)
+
+    def _mask_lines(self, string):
+        if not hasattr(self, 'masking_pattern'):
+            return string
+        elif self.masking_pattern is None:
+            return string
+        else:
+            pattern = self.masking_pattern
+
+            def asterisks_repl(match):
+                return len(match[0]) * '*'
+
+            return re.sub(pattern, asterisks_repl, string)
 
     def _get_cell_id(self, parent):
         if 'content' not in parent:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,90 @@
+import re
+import unittest
+
+from logging import getLogger, StreamHandler, DEBUG, INFO
+
+from lc_wrapper import kernel
+
+
+log = getLogger(__name__)
+
+
+class DummyKernel(kernel.BufferedKernelBase):
+
+    def _get_wrapped_kernel_name(self):
+        return 'python3'
+
+
+class TestKernel(unittest.TestCase):
+
+    def setUp(self):
+        self.instance = DummyKernel(log=log)
+        self.test_mask_target = '''
+a@b.com
+1234567890
+aaa bbb ccc
+日本語
+'''
+
+    def test_should_not_mask_without_config(self):
+        target = self.test_mask_target
+
+        masked = self.instance._mask_lines(target)
+
+        self.assertEqual(masked, target)
+
+    def test_mask_not_matched(self):
+        pattern = re.compile(r'nothing')
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+
+        self.assertEqual(masked, target)
+
+    def test_mask_something(self):
+        pattern_list = [
+            'aaa',
+            '日本',
+            '語',
+            '[0-9]+',
+            '[a-z]+@[a-z]+.com',
+        ]
+        target = self.test_mask_target
+
+        for pattern in pattern_list:
+            self.instance.masking_pattern = pattern
+
+            masked = self.instance._mask_lines(target)
+
+            self.assertNotEqual(masked, target)
+            self.assertIn('*', masked)
+
+    def test_mask_numbers(self):
+        pattern = r'[0-9]+'
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+        expected = '''
+a@b.com
+**********
+aaa bbb ccc
+日本語
+'''
+        self.assertEqual(masked, expected)
+
+    def test_mask_email(self):
+        pattern = '[a-z]+@[a-z\.]+.com'
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+        expected = '''
+*******
+1234567890
+aaa bbb ccc
+日本語
+'''
+
+        self.assertEqual(masked, expected)


### PR DESCRIPTION
### Summary

Introduce a new variable `lc_wrapper_masking_pattern` to prevent users from saving credentials in notebooks and log files accidentally.

![image](https://user-images.githubusercontent.com/144761/52992112-b6c77b80-3452-11e9-84cd-d658946b0854.png)

### Design and implementation status

* [x] Mask credential substrings in output code cells with regexp, whichever "summarized" or not
* [x] Mask credential substrings in stderr
* [x] Mask credential substrings in log files
* [ ] Mask credential substrings in traceback messages

![image](https://user-images.githubusercontent.com/144761/52992136-cd6dd280-3452-11e9-8156-d3e5c2955ef9.png)

* This feature does nothing in below condition:
  * When no pattern is given in config file nor environment variables
  * Markdown cells
  * Input code cells

If you have any comments, suggestions or questions, I would love to hear from you.
