### PR TITLE
 Log a status field of an execute_reply message

### DIFF
--- a/lc_wrapper/kernel.py
+++ b/lc_wrapper/kernel.py
@@ -482,6 +482,8 @@ class BufferedKernelBase(Kernel):
             'log_path': self.file_full_path
         }
 
+        self.exec_info.execute_reply_status = content['status']
+
         return content
 
     def _post_send_reply_msg(self, parent, reply_msg):
@@ -814,6 +816,7 @@ class BufferedKernelBase(Kernel):
             self.log_buff_append(u'\n----\n{}----\n'.format(self.exec_info.to_logfile_footer()))
             for result in self.result_files:
                 self.log_buff_append(u'result: {}\n'.format(result))
+            self.log_buff_append(u'execute_reply_status: {}\n'.format(self.exec_info.execute_reply_status))
             self.block_messages = True
 
             self._log_buff_flush(force=True)

--- a/lc_wrapper/log.py
+++ b/lc_wrapper/log.py
@@ -3,20 +3,6 @@ import dateutil
 import os
 
 
-def parse_execution_info_log(log):
-    r = ExecutionInfo(log['code'])
-    r.log_path = log['path']
-    r.start_time = log['start']
-    r.end_time = log['end']
-    r.file_size = log['size']
-    r.server_signature = log.get('server_signature', None)
-    r.uid = log.get('uid', None)
-    r.gid = log.get('gid', None)
-    r.notebook_path = log.get('notebook_path', None)
-    r.lc_notebook_meme = log.get('lc_notebook_meme', None)
-    r.execute_reply_status = log.get('execute_reply_status', None)
-    return r
-
 class ExecutionInfo(object):
     def __init__(self, code, server_signature=None, notebook_data=None):
         self.code = code

--- a/lc_wrapper/log.py
+++ b/lc_wrapper/log.py
@@ -14,6 +14,7 @@ def parse_execution_info_log(log):
     r.gid = log.get('gid', None)
     r.notebook_path = log.get('notebook_path', None)
     r.lc_notebook_meme = log.get('lc_notebook_meme', None)
+    r.execute_reply_status = log.get('execute_reply_status', None)
     return r
 
 class ExecutionInfo(object):
@@ -33,6 +34,7 @@ class ExecutionInfo(object):
         else:
             self.notebook_path = None
             self.lc_notebook_meme = None
+        self.execute_reply_status = None
 
     def finished(self, keyword_buff_size):
         self.end_time = datetime.now(dateutil.tz.tzlocal()).strftime('%Y-%m-%d %H:%M:%S(%Z)')
@@ -97,6 +99,7 @@ class ExecutionInfo(object):
                'uid': self.uid,
                'gid': self.gid,
                'notebook_path': self.notebook_path,
-               'lc_notebook_meme': self.lc_notebook_meme
+               'lc_notebook_meme': self.lc_notebook_meme,
+               'execute_reply_status': self.execute_reply_status
               }
         return log


### PR DESCRIPTION
* Add an `execute_reply_status: ` line to the tail of the log file (`*.log`)
* Add an `execute_reply_status` field to items of the history log file (`*.json`)