### PR TITLE
Implement functionality for masking credentials (the 2nd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 # Jupyter-LC_wrapper
 
   Jupyter-LC_wrapper, we call lc_wrapper, is a wrapper kernel that relay the code and messages between the ipython kernel and the notebook server.
-  The original ipython kernel is hard to use at the time of huge output. The behavior of the browser slows down, and it stops working at the worst. The lc_wrapper resolved this difficulty by summarizing the data sent to the notebook server.  
+  The original ipython kernel is hard to use at the time of huge output. The behavior of the browser slows down, and it stops working at the worst. The lc_wrapper resolved this difficulty by summarizing the data sent to the notebook server. 
+  And, if you are planning to distribute notebooks, you should avoid printing secret information (ex. secret-key, telephone-no., etc) in the notebooks. The lc_wrapper has the ability to mask specified patterns in notebooks and log files.
+
 The lc_wrapper has several features shown below:
 
-* Turn on and off this features easily.
+* Turn on and off this summarize features easily.
 * It is summarized that the contents displayed on the output area of the notebook.
 * The specified keywords can be checked.
 * The output results are saved in the files with the executed history.
@@ -122,6 +124,20 @@ Example:
 ---
 !!!ls -al
 ```
+
+### Enabling Masking feature
+The masking feature is enabled when it is installed.
+
+Specify the pattern to mask, in lc_wrapper_masking_pattern.
+
+Specify whether or not to mask the string in log file as well as the notebooks, in lc_wrapper_mask_log.
+
+This specifications can be set by environment variables or in configuration file.
+The environment variables overrides the variables in the configuration file.
+If neither setting is present, the default variables are used.
+
+Set the lc_wrapper_masking_pattern to undefined, if you do not want to apply the masking feature.
+When the pattern is undefined, the system returns the raw output string as is.
 
 ### Settings by configuration file
 
@@ -259,9 +275,9 @@ Output Size(byte): 189, Lines: 16, Path: /notebooks/.log/20170426/20170426-14391
 
 #### `lc_wrapper_masking_pattern`
 
-Mask the keywords of the output and log file with variable 'lc_wrapper_masking_pattern'.
+Mask the keywords of the output and log files with variable 'lc_wrapper_masking_pattern'.
  
-The meaning of value is as follows.
+The meaning of variable is as follows.
 
 ```
 lc_wrapper_masking_pattern=z
@@ -286,12 +302,12 @@ output size: 474 bytes
 **** is ***
 ```
 
-Example2: `lc_wrapper_masking_pattern=home|abc|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com`
+Example2: `lc_wrapper_masking_pattern=((070|080|090)-\d{4}-\d{4}|0\d-\d{4}-\d{4}|0\d{1,2}-\d{3,4}-\d{4})|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com`
 
 ```
 [In]
 ---
-!!print("home,123,jamine_wewe@163.com")
+!!print("home: kawasaki-si,phone: 090-1234-5678,e-mail: jamine_wewe@163.com")
 
 [Out]
 ---
@@ -301,14 +317,14 @@ end time: 2018-11-27 05:45:28(UTC)
 output size: 494 bytes
 0 chunks with matched keywords or errors
 ----
-****,123,*******************
+home: kawasaki-si,phone: *************,e-mail: *******************
 ```
 
 #### `lc_wrapper_mask_log`
 
 When value is `on`, mask the secret words (strings that matches to lc_wrapper_masking_pattern) with "***..." in the log file. 
 
-And when it is `off` or otherwise,  strings in log files are not masked. 
+And when it is `off` or otherwise, strings in log files are not masked. 
 
 default value is `on`.
 
@@ -326,7 +342,7 @@ $ export lc_wrapper_masking_pattern='[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com'
 $ export lc_wrapper_mask_log=off
 ```
 
-The name of environemnt variable is same to the key name of the configuration file.
+The name of environment variable is same to the key name of the configuration file.
 
 If you set both the configuration file and environment variables, the environment variables are applied and the duplicated entries in the configuration file are ignored.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This is an example of `.lc_wrapper` file.
 lc_wrapper_force=on
 lc_wrapper=2:2:2:2
 lc_wrapper_regex=3|5|7
+lc_wrapper_masking_pattern=(?:[0-9]{11}@[a-z]*.proxy.example.com:8080)|AKIAJTQHFTLP426OCK3Q|2468
 ```
 
 #### `lc_wrapper_force`
@@ -254,6 +255,55 @@ Output Size(byte): 189, Lines: 16, Path: /notebooks/.log/20170426/20170426-14391
 9
 ```
 
+#### `lc_wrapper_masking_pattern`
+
+Mask the keywords of the output and log file with variable 'lc_wrapper_masking_pattern'.
+
+The meaning of value is as follows.
+
+```
+lc_wrapper_masking_pattern=z
+z = keywords : If mask two words word1 and word2, write with a separator '|' such as z = word1|word2.
+z = regex : If use regular expression, write with a regular expression such as z = [0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com.
+z = keywords | regex : If use words and regular expression, write with a separator '|' such as z = word1|word2|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com
+```
+
+Example1: `lc_wrapper_masking_pattern=home|123`
+
+```
+[In]
+---
+!!print("home is 123")
+
+[Out]
+---
+path: /notebooks/.log/20181127/20181127-032445-0875.log (2 logs recorded)
+start time: 2018-11-27 03:24:45(UTC)
+end time: 2018-11-27 03:24:45(UTC)
+output size: 474 bytes
+0 chunks with matched keywords or errors
+----
+**** is ***
+```
+
+Example2: `lc_wrapper_masking_pattern=home|abc|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com`
+
+```
+[In]
+---
+!!print("home,123,jamine_wewe@163.com")
+
+[Out]
+---
+path: /notebooks/.log/20181127/20181127-054528-0906.log (9 logs recorded)
+start time: 2018-11-27 05:45:28(UTC)
+end time: 2018-11-27 05:45:28(UTC)
+output size: 494 bytes
+0 chunks with matched keywords or errors
+----
+****,123,*******************
+```
+
 ### Settings by environment variables
 
 Instead of the configuration file, you can set with the environment variables.
@@ -264,6 +314,7 @@ For example, set the environment variables as follows.
 $ export lc_wrapper_force='on'
 $ export lc_wrapper='2:2:2:2'
 $ export lc_wrapper_regex='3|5|7'
+$ export lc_wrapper_masking_pattern='[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com'
 ```
 
 The name of environemnt variable is same to the key name of the configuration file.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The lc_wrapper has several features shown below:
 * It is summarized that the contents displayed on the output area of the notebook.
 * The specified keywords can be checked.
 * The output results are saved in the files with the executed history.
+* Secrets words that specified by "pattern regexp" are masked with '***...'.
 
 ## Prerequisite
 
@@ -143,6 +144,7 @@ lc_wrapper_force=on
 lc_wrapper=2:2:2:2
 lc_wrapper_regex=3|5|7
 lc_wrapper_masking_pattern=(?:[0-9]{11}@[a-z]*.proxy.example.com:8080)|AKIAJTQHFTLP426OCK3Q|2468
+lc_wrapper_mask_log=on
 ```
 
 #### `lc_wrapper_force`
@@ -258,14 +260,12 @@ Output Size(byte): 189, Lines: 16, Path: /notebooks/.log/20170426/20170426-14391
 #### `lc_wrapper_masking_pattern`
 
 Mask the keywords of the output and log file with variable 'lc_wrapper_masking_pattern'.
-
+ 
 The meaning of value is as follows.
 
 ```
 lc_wrapper_masking_pattern=z
-z = keywords : If mask two words word1 and word2, write with a separator '|' such as z = word1|word2.
-z = regex : If use regular expression, write with a regular expression such as z = [0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com.
-z = keywords | regex : If use words and regular expression, write with a separator '|' such as z = word1|word2|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com
+z is a regular expression to mask. Ex.) pass_word|[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com|AKIAIOSFODNN7EXAMPLE .
 ```
 
 Example1: `lc_wrapper_masking_pattern=home|123`
@@ -304,6 +304,14 @@ output size: 494 bytes
 ****,123,*******************
 ```
 
+#### `lc_wrapper_mask_log`
+
+When value is `on`, mask the secret words (strings that matches to lc_wrapper_masking_pattern) with "***..." in the log file. 
+
+And when it is `off` or otherwise,  strings in log files are not masked. 
+
+default value is `on`.
+
 ### Settings by environment variables
 
 Instead of the configuration file, you can set with the environment variables.
@@ -315,6 +323,7 @@ $ export lc_wrapper_force='on'
 $ export lc_wrapper='2:2:2:2'
 $ export lc_wrapper_regex='3|5|7'
 $ export lc_wrapper_masking_pattern='[0-9a-zA-Z_]+@[0-9a-zA-Z.]+?com'
+$ export lc_wrapper_mask_log=off
 ```
 
 The name of environemnt variable is same to the key name of the configuration file.

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,90 @@
+import re
+import unittest
+
+from logging import getLogger, StreamHandler, DEBUG, INFO
+
+from lc_wrapper import kernel
+
+
+log = getLogger(__name__)
+
+
+class DummyKernel(kernel.BufferedKernelBase):
+
+    def _get_wrapped_kernel_name(self):
+        return 'python3'
+
+
+class TestKernel(unittest.TestCase):
+
+    def setUp(self):
+        self.instance = DummyKernel(log=log)
+        self.test_mask_target = '''
+a@b.com
+1234567890
+aaa bbb ccc
+日本語
+'''
+
+    def test_should_not_mask_without_config(self):
+        target = self.test_mask_target
+
+        masked = self.instance._mask_lines(target)
+
+        self.assertEqual(masked, target)
+
+    def test_mask_not_matched(self):
+        pattern = re.compile(r'nothing')
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+
+        self.assertEqual(masked, target)
+
+    def test_mask_something(self):
+        pattern_list = [
+            'aaa',
+            '日本',
+            '語',
+            '[0-9]+',
+            '[a-z]+@[a-z]+.com',
+        ]
+        target = self.test_mask_target
+
+        for pattern in pattern_list:
+            self.instance.masking_pattern = pattern
+
+            masked = self.instance._mask_lines(target)
+
+            self.assertNotEqual(masked, target)
+            self.assertIn('*', masked)
+
+    def test_mask_numbers(self):
+        pattern = r'[0-9]+'
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+        expected = '''
+a@b.com
+**********
+aaa bbb ccc
+日本語
+'''
+        self.assertEqual(masked, expected)
+
+    def test_mask_email(self):
+        pattern = '[a-z]+@[a-z\.]+.com'
+        target = self.test_mask_target
+        self.instance.masking_pattern = pattern
+
+        masked = self.instance._mask_lines(target)
+        expected = '''
+*******
+1234567890
+aaa bbb ccc
+日本語
+'''
+
+        self.assertEqual(masked, expected)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5,9 +5,14 @@ from logging import getLogger, StreamHandler, DEBUG, INFO
 
 from lc_wrapper import kernel
 
+from datetime import datetime
+import dateutil
+import os 
+import pickle
+import test.support
+import tempfile
 
 log = getLogger(__name__)
-
 
 class DummyKernel(kernel.BufferedKernelBase):
 
@@ -25,6 +30,10 @@ a@b.com
 aaa bbb ccc
 日本語
 '''
+
+    def tearDown(self):
+        self.instance.log_file_object=None
+        self.instance.do_shutdown(False)
 
     def test_should_not_mask_without_config(self):
         target = self.test_mask_target
@@ -88,3 +97,136 @@ aaa bbb ccc
 '''
 
         self.assertEqual(masked, expected)
+
+    def test_mask_binary(self) : 
+        pattern='passwa(\-)*d'
+        target='\x1b[0;31m----------\x1b[0mpasswa---d\x1b[0;34m----------\x1b[0m'
+        result='\x1b[0;31m----------\x1b[0m**********\x1b[0;34m----------\x1b[0m'
+
+        self.instance.masking_pattern = pattern
+        masked=self.instance._mask_lines(target)
+
+        self.assertEqual(masked, result)        
+
+    def test_read_mask_flag_from_env(self):
+        self.set_env_LOG_MASKING_KEY('on')
+        self.instance.notebook_path=self.create_dummy_notebook_home("off")
+        self.prepare_dummy_kernel_settings()
+
+        env = self.instance._get_config() 
+
+        if kernel.LOG_MASKING_KEY in env:
+            flag = env.get(kernel.LOG_MASKING_KEY)
+        else :
+            flag=None
+
+        self.delete_dummy_notebook_home()
+        
+        self.assertEqual(flag, 'on')        
+
+    def test_read_mask_flag_from_config_file(self):
+        self.set_env_LOG_MASKING_KEY("")
+        self.instance.notebook_path=self.create_dummy_notebook_home("off")
+        self.prepare_dummy_kernel_settings()
+
+        env = self.instance._get_config() 
+
+        if kernel.LOG_MASKING_KEY in env:
+            flag = env.get(kernel.LOG_MASKING_KEY)
+        else :
+            flag=None
+
+        self.delete_dummy_notebook_home()
+        self.assertEqual(flag, 'off')
+
+    def test_load_env_mask_flag_use_config_(self):
+        self.set_env_LOG_MASKING_KEY("")
+        self.instance.notebook_path=self.create_dummy_notebook_home("off")
+        self.prepare_dummy_kernel_settings()
+
+        env = {}
+        env[kernel.MASKING_KEY]='passwa(\-)*d'
+        env[kernel.LOG_MASKING_KEY]='off'
+
+        self.instance._load_env(env) 
+
+        flag=self.instance.log_mask # on as default
+
+        self.delete_dummy_notebook_home()
+
+        self.assertEqual(flag, 'off')
+
+    def test_load_env_mask_flag_use_default_env_not_found(self):
+        self.set_env_LOG_MASKING_KEY("")
+        self.instance.notebook_path=self.create_dummy_notebook_home("")
+        self.prepare_dummy_kernel_settings()
+
+        env = {}
+        env[kernel.MASKING_KEY]='passwa(\-)*d'
+
+        self.instance._load_env(env) 
+
+        flag=self.instance.log_mask # on as default
+
+        self.delete_dummy_notebook_home()
+
+        self.assertEqual(flag, 'on')
+
+    def test_load_env_mask_flag_use_default_env_not_defined(self):
+        self.set_env_LOG_MASKING_KEY("")
+        self.instance.notebook_path=self.create_dummy_notebook_home("")
+        self.prepare_dummy_kernel_settings()
+
+        env = {}
+
+        self.instance._load_env(env) 
+
+        flag=self.instance.log_mask # on as default
+
+        self.delete_dummy_notebook_home()
+
+        self.assertEqual(flag, 'on')
+
+    # subfunctions
+    def create_dummy_notebook_home(self, v_lc_wrapper_mask_log):
+        self.work_dir=tempfile.TemporaryDirectory()
+
+        self.reg_pattern_file =os.path.join(self.work_dir.name, kernel.IPYTHON_DEFAULT_PATTERN_FILE)
+        reg_pattern =kernel.IPYTHON_DEFAULT_PATTERN
+        if not os.path.exists(self.reg_pattern_file):
+            f = open(self.reg_pattern_file, 'w')
+            f.write(reg_pattern)
+            f.close()
+        self.instance.keyword_pattern_file_paths = [self.reg_pattern_file]
+
+        self.config_file=os.path.join(self.work_dir.name, ".lc_wrapper")
+        f = open(self.config_file, 'a')
+        if len(v_lc_wrapper_mask_log) == 0 :
+            f.write("\n")
+        else :
+            f.write("lc_wrapper_mask_log=" + v_lc_wrapper_mask_log + "\n")
+        f.close()
+        self.instance.configfile_paths = [self.config_file]
+
+        return self.work_dir.name
+
+    def delete_dummy_notebook_home(self):
+        self.work_dir.cleanup()
+        return
+
+    def set_env_LOG_MASKING_KEY(self, v_LOG_MASKING_KEY): 
+        if (len(v_LOG_MASKING_KEY)>0) :
+            test.support.EnvironmentVarGuard().set(kernel.LOG_MASKING_KEY,v_LOG_MASKING_KEY)
+        else:
+            if (kernel.LOG_MASKING_KEY in os.environ) :
+                test.support.EnvironmentVarGuard().unset(kernel.LOG_MASKING_KEY)
+        return
+
+    def prepare_dummy_kernel_settings(self) :
+        self.instance.summarize_start_lines = 50
+        self.instance.summarize_header_lines = 20
+        self.instance.summarize_exec_lines = 1
+        self.instance.summarize_footer_lines = 20
+
+        self.instance.log_history_file_path = None
+


### PR DESCRIPTION
Summary :

  Introduce a new variable lc_wrapper_masking_pattern and lc_wrapper_mask_log to prevent users from saving credentials in notebooks and log files accidentally.

![mask20190622](https://user-images.githubusercontent.com/50895947/60090247-23de7b00-977d-11e9-86f6-1cac5640fa42.jpg)

  If you afraid you can't get correct output for unexpected masking,
  set lc_wrapper_mask_log=off (strings in log files are not masked), and find correct strings in log files.

Implementation status :

  - Mask credential substrings in output code cells with regexp, whichever "summarized" or not

  - Mask credential substrings in stderr

  - Mask credential substrings in log files and pkl files, when lc_wrapper_mask_log=on or lc_wrapper_mask_log is undefined

  - Mask credential substrings in traceback messages

This feature does nothing in below condition :
  - When no pattern is given in config file nor environment variables.

  - Markdown cells (and Heading cells).

  - Raw NBConvert cells.

  - Input code cells.

History :
  
  This is an improved version of "Pull Request #50".
  - Mask the track back as well
  - flag to select whether or not to mask log

And :
  
  If you have any comments, suggestions or questions, I would love to hear from you.