### PR TITLE
Fix for compatibility with jupyter-client 7.x

### DIFF
--- a/lc_wrapper/kernel.py
+++ b/lc_wrapper/kernel.py
@@ -1089,4 +1089,4 @@ class LCWrapperKernelManager(IOLoopKernelManager):
             # most 1s, checking every 0.1s.
             self.finish_shutdown()
 
-        self.cleanup(connection_file=not restart)
+        self.cleanup_resources(restart=restart)

--- a/lc_wrapper/kernel.py
+++ b/lc_wrapper/kernel.py
@@ -85,9 +85,11 @@ class ChannelReaderThread(Thread, LoggingConfigurable):
         self.log.debug("start ChannelReaderThread: channel_name=%s",
                        self.channel_name)
 
+        get_msg = getattr(self.client, 'get_%s_msg' % self.channel_name)
+
         while True:
             try:
-                msg = self.channel.get_msg(block=True, timeout=0.2)
+                msg = get_msg(timeout=0.2)
                 self.log.debug("Received %s message: %s",
                                self.channel_name, str(msg))
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,12 @@ setup(
     name='lc_wrapper',
     version=VERSION_NS['__version__'],
     packages=['lc_wrapper', 'lc_wrapper.ipython', 'lc_wrapper.bash'],
-    install_requires=['ipykernel>=4.0.0', 'jupyter_client', 'python-dateutil', 'fluent-logger'],
+    install_requires=[
+        'ipykernel>=4.0.0',
+        'jupyter_client!=7.0.0,!=7.0.1,!=7.0.2,!=7.0.3',
+        'python-dateutil',
+        'fluent-logger'
+    ],
     description='Kernel Wrapper for Literate Computing',
     author='NII Cloud Operation Team',
     url='https://github.com/NII-cloud-operation/',


### PR DESCRIPTION
- Use get_*_msg channel proxy methods, fix #59 
- Use cleanup_resources() instead of cleanup()
- Exclude jupyter_client incompatibility versions from install_requires