### PR TITLE
Remove jupyter_core pin workaround for issue 71

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ ENV PATH=/.npm/bin/:${PATH}
 COPY . /tmp/wrapper
 RUN pip --no-cache-dir install /tmp/wrapper
 
-# Workaround for https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/issues/71
-RUN pip install --upgrade jupyter_core==5.6.1
-
 # Install nblineage
 RUN pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-LC_nblineage.git
 


### PR DESCRIPTION
## Summary
- remove the Dockerfile workaround that pinned jupyter_core to 5.6.1
- rely on the current scipy-notebook base image dependency set
- fix #71

## Context
Issue #71 includes the observation: "With jupyter_core 5.8.1 and ipykernel 7.0.0a1, it looks to work."
Based on the current verification, it seems likely that the problem no longer occurs with the latest dependency combination.

## Verification
- built the Docker image without the jupyter_core pin
- confirmed the container resolved to jupyter_core 5.9.1, ipykernel 7.1.0, and jupyter_client 8.7.0
- opened JupyterLab in the browser and confirmed a new notebook reached `Python 3 | Idle`
- executed a cell successfully and verified `input()` also worked