### PR TITLE
Remove ipython_genutils dependency from lc_wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:notebook-7.5.0
+FROM quay.io/jupyter/scipy-notebook:notebook-7.5.5
 
 USER root
 

--- a/lc_wrapper/ipython/install.py
+++ b/lc_wrapper/ipython/install.py
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 
-from ipython_genutils.py3compat import PY3
 from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
@@ -62,7 +61,7 @@ def main(argv=None):
     install_my_kernel_spec('lc_wrapper', wrapper_kernel_json,
                            user=args.user, prefix=args.prefix,
                            kernelspec_manager_class=KernelSpecManager)
-    install_my_kernel_spec('python3' if PY3 else 'python2', kernel_json,
+    install_my_kernel_spec('python3', kernel_json,
                            user=args.user, prefix=args.prefix,
                            kernelspec_manager_class=LCWrapperKernelSpecManager)
 

--- a/lc_wrapper/ipython/kernel.py
+++ b/lc_wrapper/ipython/kernel.py
@@ -1,5 +1,4 @@
 import sys
-from ipython_genutils.py3compat import PY3
 
 from ..kernel import BufferedKernelBase
 
@@ -12,12 +11,11 @@ class PythonKernelBuffered(BufferedKernelBase):
         'name': 'python',
         'version': sys.version.split()[0],
         'mimetype': 'text/x-python',
-        'pygments_lexer': 'ipython%d' % (3 if PY3 else 2),
+        'pygments_lexer': 'ipython3',
         'nbconvert_exporter': 'python',
         'file_extension': '.py'
     }
     banner = 'Literate Computing Wrapper Kernel(IPython)'
 
     def _get_wrapped_kernel_name(self):
-        return 'python3' if PY3 else 'python2'
-
+        return 'python3'

--- a/lc_wrapper/kernel.py
+++ b/lc_wrapper/kernel.py
@@ -1,9 +1,4 @@
-from __future__ import print_function
-
-try:
-    from queue import Empty  # Python 3
-except ImportError:
-    from Queue import Empty  # Python 2
+from queue import Empty
 import time
 import io
 from collections.abc import Mapping
@@ -20,10 +15,7 @@ import re
 import json
 from threading import (Thread, Event, Timer)
 
-try:
-    from os import getcwdu as getcwd  # Python 2
-except ImportError:
-    from os import getcwd  # Python 3
+from os import getcwd
 import pickle
 import dateutil
 from .log import ExecutionInfo
@@ -33,8 +25,6 @@ from traitlets.config.configurable import LoggingConfigurable, MultipleInstanceE
 from traitlets import (
     Unicode, List, default
 )
-from ipython_genutils import py3compat
-from ipython_genutils.py3compat import PY3
 from types import MethodType
 from fluent import sender
 
@@ -357,20 +347,14 @@ class BufferedKernelBase(Kernel):
 
             self.log.debug('override shell message handler: msg_type=%s', msg_type)
 
-            if PY3:
-                setattr(self, msg_type, MethodType(handler, self))
-            else:
-                setattr(self, msg_type, MethodType(handler, self, type(self)))
+            setattr(self, msg_type, MethodType(handler, self))
             self.shell_handlers[msg_type] = getattr(self, msg_type)
 
         comm_msg_types = ['comm_open', 'comm_msg', 'comm_close']
         for msg_type in comm_msg_types:
             self.log.debug('init shell comm message handler: msg_type=%s', msg_type)
 
-            if PY3:
-                setattr(self, msg_type, MethodType(handler, self))
-            else:
-                setattr(self, msg_type, MethodType(handler, self, type(self)))
+            setattr(self, msg_type, MethodType(handler, self))
             self.shell_handlers[msg_type] = getattr(self, msg_type)
 
     def start_ipython_kernel(self):
@@ -450,7 +434,7 @@ class BufferedKernelBase(Kernel):
     def _hook_execute_request_msg(self, parent):
         try:
             content = parent[u'content']
-            code = py3compat.cast_unicode_py2(content[u'code'])
+            code = content[u'code']
             silent = content[u'silent']
             allow_stdin = content.get('allow_stdin', False)
         except:


### PR DESCRIPTION
- remove `ipython_genutils` usage from `lc_wrapper`, because removing `nbclassic` also removes `ipython_genutils`
- simplify Python 2 compatibility branches to Python 3-only code paths
- update scipy-notebook base image to `notebook-7.5.5`